### PR TITLE
cockroachdb: fork sentry-go, also make the inAppFrame logic customizable

### DIFF
--- a/echo/sentryecho.go
+++ b/echo/sentryecho.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/labstack/echo/v4"
 )
 

--- a/example/basic/main.go
+++ b/example/basic/main.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 func prettyPrint(v interface{}) string {

--- a/example/echo/main.go
+++ b/example/echo/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getsentry/sentry-go"
-	sentryecho "github.com/getsentry/sentry-go/echo"
+	"github.com/cockroachdb/sentry-go"
+	sentryecho "github.com/cockroachdb/sentry-go/echo"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )

--- a/example/fasthttp/main.go
+++ b/example/fasthttp/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/getsentry/sentry-go"
-	sentryfasthttp "github.com/getsentry/sentry-go/fasthttp"
+	"github.com/cockroachdb/sentry-go"
+	sentryfasthttp "github.com/cockroachdb/sentry-go/fasthttp"
 	"github.com/valyala/fasthttp"
 )
 

--- a/example/flush/main.go
+++ b/example/flush/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 func main() {

--- a/example/gin/main.go
+++ b/example/gin/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getsentry/sentry-go"
-	sentrygin "github.com/getsentry/sentry-go/gin"
+	"github.com/cockroachdb/sentry-go"
+	sentrygin "github.com/cockroachdb/sentry-go/gin"
 	"github.com/gin-gonic/gin"
 )
 

--- a/example/http/main.go
+++ b/example/http/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getsentry/sentry-go"
-	sentryhttp "github.com/getsentry/sentry-go/http"
+	"github.com/cockroachdb/sentry-go"
+	sentryhttp "github.com/cockroachdb/sentry-go/http"
 )
 
 type handler struct{}

--- a/example/iris/main.go
+++ b/example/iris/main.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getsentry/sentry-go"
-	sentryiris "github.com/getsentry/sentry-go/iris"
+	"github.com/cockroachdb/sentry-go"
+	sentryiris "github.com/cockroachdb/sentry-go/iris"
 	"github.com/kataras/iris/v12"
 )
 

--- a/example/martini/main.go
+++ b/example/martini/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	sentrymartini "github.com/getsentry/sentry-go/martini"
+	sentrymartini "github.com/cockroachdb/sentry-go/martini"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/go-martini/martini"
 )
 

--- a/example/multiclient/main.go
+++ b/example/multiclient/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 type pickleIntegration struct{}

--- a/example/negroni/main.go
+++ b/example/negroni/main.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	sentrynegroni "github.com/getsentry/sentry-go/negroni"
+	sentrynegroni "github.com/cockroachdb/sentry-go/negroni"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/urfave/negroni"
 )
 

--- a/example/recover/main.go
+++ b/example/recover/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 func prettyPrint(v interface{}) string {

--- a/example/synctransport/main.go
+++ b/example/synctransport/main.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 func main() {

--- a/example/with_extra/main.go
+++ b/example/with_extra/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 func prettyPrint(v interface{}) string {

--- a/fasthttp/sentryfasthttp.go
+++ b/fasthttp/sentryfasthttp.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/valyala/fasthttp"
 )
 

--- a/gin/sentrygin.go
+++ b/gin/sentrygin.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/gin-gonic/gin"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/getsentry/sentry-go
+module github.com/cockroachdb/sentry-go
 
 go 1.11
 

--- a/http/sentryhttp.go
+++ b/http/sentryhttp.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 type Handler struct {

--- a/in_app.go
+++ b/in_app.go
@@ -1,0 +1,34 @@
+package sentry
+
+import (
+	"go/build"
+	"strings"
+)
+
+func isInAppFrame(frame Frame) bool {
+	if frame.Module == "main" {
+		return true
+	}
+	// If the client is overriding the in-app detection logic, use that.
+	if isInAppFrameFn != nil {
+		return isInAppFrameFn(frame)
+	}
+
+	// Legacy sentry-go behavior.
+	if strings.HasPrefix(frame.AbsPath, build.Default.GOROOT) ||
+		strings.Contains(frame.Module, "/vendor/") ||
+		strings.Contains(frame.Module, "/third_party/") {
+		return false
+	}
+
+	return true
+}
+
+var isInAppFrameFn func(Frame) bool
+
+// RegisterInAppFrameFn can be used by clients to customize the logic
+// that decides whether a frame is considered "in-app" for event
+// reporting.
+func RegisterInAppFrameFn(fn func(Frame) bool) {
+	isInAppFrameFn = fn
+}

--- a/integrations_test.go
+++ b/integrations_test.go
@@ -183,7 +183,7 @@ func TestContextifyFrames(t *testing.T) {
 
 	frames := cfi.contextify([]Frame{{
 		Function: "Trace",
-		Module:   "github.com/getsentry/sentry-go",
+		Module:   "github.com/cockroachdb/sentry-go",
 		Filename: filename,
 		AbsPath:  abspath,
 		Lineno:   12,

--- a/iris/sentryiris.go
+++ b/iris/sentryiris.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/kataras/iris/v12"
 )
 

--- a/martini/sentrymartini.go
+++ b/martini/sentrymartini.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/go-martini/martini"
 )
 

--- a/negroni/sentrynegroni.go
+++ b/negroni/sentrynegroni.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 	"github.com/urfave/negroni"
 )
 

--- a/scope_concurrency_test.go
+++ b/scope_concurrency_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 func TestConcurrentScopeUsage(t *testing.T) {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -1,7 +1,6 @@
 package sentry
 
 import (
-	"go/build"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -230,16 +229,6 @@ func filterFrames(frames []Frame) []Frame {
 	}
 
 	return filteredFrames
-}
-
-func isInAppFrame(frame Frame) bool {
-	if strings.HasPrefix(frame.AbsPath, build.Default.GOROOT) ||
-		strings.Contains(frame.Module, "vendor") ||
-		strings.Contains(frame.Module, "third_party") {
-		return false
-	}
-
-	return true
 }
 
 func callerFunctionName() string {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -222,7 +222,7 @@ func filterFrames(frames []Frame) []Frame {
 		}
 		// Skip Sentry internal frames, except for frames in _test packages (for
 		// testing).
-		if strings.HasPrefix(frame.Module, "github.com/getsentry/sentry-go") &&
+		if strings.HasPrefix(frame.Module, "github.com/cockroachdb/sentry-go") &&
 			!strings.HasSuffix(frame.Module, "_test") {
 			continue
 		}

--- a/stacktrace_external_test.go
+++ b/stacktrace_external_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/getsentry/sentry-go"
+	"github.com/cockroachdb/sentry-go"
 )
 
 func f1() *sentry.Stacktrace {
@@ -59,7 +59,7 @@ func TestNewStacktrace(t *testing.T) {
 			Frames: []sentry.Frame{
 				{
 					Function: "f1",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   18,
@@ -71,7 +71,7 @@ func TestNewStacktrace(t *testing.T) {
 			Frames: []sentry.Frame{
 				{
 					Function: "f2",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   22,
@@ -79,7 +79,7 @@ func TestNewStacktrace(t *testing.T) {
 				},
 				{
 					Function: "f1",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   18,
@@ -96,7 +96,7 @@ func TestNewStacktrace(t *testing.T) {
 			Frames: []sentry.Frame{
 				{
 					Function: "f3",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   25,
@@ -127,7 +127,7 @@ func TestExtractStacktrace(t *testing.T) {
 			Frames: []sentry.Frame{
 				{
 					Function: "RedPkgErrorsRanger",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   29,
@@ -135,7 +135,7 @@ func TestExtractStacktrace(t *testing.T) {
 				},
 				{
 					Function: "BluePkgErrorsRanger",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   33,
@@ -148,7 +148,7 @@ func TestExtractStacktrace(t *testing.T) {
 			Frames: []sentry.Frame{
 				{
 					Function: "RedPingcapErrorsRanger",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   37,
@@ -156,7 +156,7 @@ func TestExtractStacktrace(t *testing.T) {
 				},
 				{
 					Function: "BluePingcapErrorsRanger",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   41,
@@ -169,7 +169,7 @@ func TestExtractStacktrace(t *testing.T) {
 			Frames: []sentry.Frame{
 				{
 					Function: "RedGoErrorsRanger",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   45,
@@ -177,7 +177,7 @@ func TestExtractStacktrace(t *testing.T) {
 				},
 				{
 					Function: "BlueGoErrorsRanger",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					Filename: "stacktrace_external_test.go",
 					AbsPath:  "ignored",
 					Lineno:   49,

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -33,18 +33,18 @@ func TestSplitQualifiedFunctionName(t *testing.T) {
 		{"runtime.Callers", "runtime", "Callers"},
 		{"main.main.func1", "main", "main.func1"},
 		{
-			"github.com/getsentry/sentry-go.Init",
-			"github.com/getsentry/sentry-go",
+			"github.com/cockroachdb/sentry-go.Init",
+			"github.com/cockroachdb/sentry-go",
 			"Init",
 		},
 		{
-			"github.com/getsentry/sentry-go.(*Hub).Flush",
-			"github.com/getsentry/sentry-go",
+			"github.com/cockroachdb/sentry-go.(*Hub).Flush",
+			"github.com/cockroachdb/sentry-go",
 			"(*Hub).Flush",
 		},
 		{
-			"github.com/getsentry/sentry-go.Test.func2.1.1",
-			"github.com/getsentry/sentry-go",
+			"github.com/cockroachdb/sentry-go.Test.func2.1.1",
+			"github.com/cockroachdb/sentry-go",
 			"Test.func2.1.1",
 		},
 		{
@@ -92,19 +92,19 @@ func TestFilterFrames(t *testing.T) {
 				},
 				{
 					Function: "TestNewStacktrace.func1",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					AbsPath:  "/somewhere/sentry/sentry-go/stacktrace_external_test.go",
 					InApp:    true,
 				},
 				{
 					Function: "StacktraceTestHelper.NewStacktrace",
-					Module:   "github.com/getsentry/sentry-go",
+					Module:   "github.com/cockroachdb/sentry-go",
 					AbsPath:  "/somewhere/sentry/sentry-go/stacktrace_test.go",
 					InApp:    true,
 				},
 				{
 					Function: "NewStacktrace",
-					Module:   "github.com/getsentry/sentry-go",
+					Module:   "github.com/cockroachdb/sentry-go",
 					AbsPath:  "/somewhere/sentry/sentry-go/stacktrace.go",
 					InApp:    true,
 				},
@@ -112,7 +112,7 @@ func TestFilterFrames(t *testing.T) {
 			out: []Frame{
 				{
 					Function: "TestNewStacktrace.func1",
-					Module:   "github.com/getsentry/sentry-go_test",
+					Module:   "github.com/cockroachdb/sentry-go_test",
 					AbsPath:  "/somewhere/sentry/sentry-go/stacktrace_external_test.go",
 					InApp:    true,
 				},
@@ -123,13 +123,13 @@ func TestFilterFrames(t *testing.T) {
 			in: []Frame{
 				{
 					Function: "Example.Integration",
-					Module:   "github.com/getsentry/sentry-go/http/integration",
+					Module:   "github.com/cockroachdb/sentry-go/http/integration",
 					AbsPath:  "/somewhere/sentry/sentry-go/http/integration/integration.go",
 					InApp:    true,
 				},
 				{
 					Function: "(*Handler).Handle",
-					Module:   "github.com/getsentry/sentry-go/http",
+					Module:   "github.com/cockroachdb/sentry-go/http",
 					AbsPath:  "/somewhere/sentry/sentry-go/http/sentryhttp.go",
 					InApp:    true,
 				},


### PR DESCRIPTION
2nd commit inspired from https://github.com/cockroachdb/raven-go/pull/1, needed for CockroachDB.

@tooolbox can you also review this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/sentry-go/1)
<!-- Reviewable:end -->
